### PR TITLE
chore(project manager): add initial and hacktoberfest config

### DIFF
--- a/.github/project-manager.yml
+++ b/.github/project-manager.yml
@@ -1,0 +1,101 @@
+issue:
+  opened:
+    addLabels:
+      - butterfly
+      - core
+      - triage
+  closed:
+    addLabels:
+      - done
+
+pull_request:
+  opened:
+    addLabels:
+      - butterfly
+      - core
+  closed:
+    addLabels:
+      - done
+
+projects:  
+  - name: Global Kanban
+    type: org
+    issue_type: issue
+    columns:
+      - name: triage
+        labels:
+          - triage
+        actions:
+          removeLabels:
+            - backlog
+            - todo
+            - in progress
+            - done 
+      - name: backlog
+        labels:
+          - backlog
+        actions:
+          removeLabels:
+            - triage
+            - todo
+            - in progress
+            - done 
+      - name: todo
+        labels:
+          - todo
+        actions:
+          removeLabels:
+            - triage
+            - backlog
+            - in progress
+            - done 
+      - name: in progress
+        labels:
+          - in progress
+        actions:
+          removeLabels:
+            - triage
+            - todo
+            - backlog
+            - done
+      - name: done
+        labels:
+          - done 
+        actions:
+          removeLabels:
+            - triage
+            - backlog
+            - todo
+            - in progress
+
+  - name: Hacktoberfest
+    type: org
+    issue_type: issue
+    label: hacktoberfest
+    columns: 
+      - name: butterfly
+        labels:
+          - hacktoberfest
+      - name: done
+        labels:
+          - done
+
+labels:
+- name: butterfly
+  color: "#FFFB00"
+- name: core
+  color: "#0075CA"
+
+- name: in progress
+  color: "#EDEDED"
+- name: triage
+  color: "#EDEDED"
+- name: todo
+  color: "#EDEDED"
+- name: backlog
+  color: "#EDEDED"
+- name: done
+  color: "#EDEDED"
+
+- name: hacktoberfest
+  color: "#802AC1"


### PR DESCRIPTION
This PR is copied across a bunch of repositories to set up a global kanban to manage triage, backlog and issue progress for multiple repositories as well as enable a Hacktoberfest board to help people navigate and find issue they might want to help with.